### PR TITLE
增加SetGuidDefaultLength方法

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
@@ -12,6 +12,7 @@ namespace SqlSugar
         protected bool IsBackupTable { get; set; }
         protected int MaxBackupDataRows { get; set; }
         protected virtual int DefultLength { get; set; }
+        protected virtual int DefaultGuidLength { get; set; }
         public CodeFirstProvider()
         {
             if (DefultLength == 0)
@@ -32,6 +33,12 @@ namespace SqlSugar
         public virtual ICodeFirst SetStringDefaultLength(int length)
         {
             DefultLength = length;
+            return this;
+        }
+
+        public virtual ICodeFirst SetGuidDefaultLength(int length)
+        {
+            DefaultGuidLength = length;
             return this;
         }
 
@@ -105,6 +112,10 @@ namespace SqlSugar
                     if (item.PropertyInfo.PropertyType == UtilConstants.StringType && item.DataType.IsNullOrEmpty() && item.Length == 0)
                     {
                         item.Length = DefultLength;
+                    }
+                    if (item.PropertyInfo.PropertyType == UtilConstants.GuidType && item.DataType.IsNullOrEmpty() && item.Length == 0)
+                    {
+                        item.Length = DefaultGuidLength;
                     }
                 }
             }

--- a/Src/Asp.Net/SqlSugar/Interface/ICodeFirst.cs
+++ b/Src/Asp.Net/SqlSugar/Interface/ICodeFirst.cs
@@ -9,6 +9,7 @@ namespace SqlSugar
         SqlSugarProvider Context { get; set; }
         ICodeFirst BackupTable(int maxBackupDataRows = int.MaxValue);
         ICodeFirst SetStringDefaultLength(int length);
+        ICodeFirst SetGuidDefaultLength(int length);
         void InitTables(string entitiesNamespace);
         void InitTables(string[] entitiesNamespaces);
         void InitTables(params Type[] entityTypes);

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
@@ -12,6 +12,8 @@ namespace SqlSugar
         protected bool IsBackupTable { get; set; }
         protected int MaxBackupDataRows { get; set; }
         protected virtual int DefultLength { get; set; }
+
+        protected virtual int DefaultGuidLength { get; set; }
         public CodeFirstProvider()
         {
             if (DefultLength == 0)
@@ -32,6 +34,12 @@ namespace SqlSugar
         public virtual ICodeFirst SetStringDefaultLength(int length)
         {
             DefultLength = length;
+            return this;
+        }
+
+        public virtual ICodeFirst SetGuidDefaultLength(int length)
+        {
+            DefaultGuidLength = length;
             return this;
         }
 
@@ -105,6 +113,10 @@ namespace SqlSugar
                     if (item.PropertyInfo.PropertyType == UtilConstants.StringType && item.DataType.IsNullOrEmpty() && item.Length == 0)
                     {
                         item.Length = DefultLength;
+                    }
+                    if (item.PropertyInfo.PropertyType == UtilConstants.GuidType && item.DataType.IsNullOrEmpty() && item.Length == 0)
+                    {
+                        item.Length = DefaultGuidLength;
                     }
                 }
             }

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Interface/ICodeFirst.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Interface/ICodeFirst.cs
@@ -9,6 +9,7 @@ namespace SqlSugar
         SqlSugarProvider Context { get; set; }
         ICodeFirst BackupTable(int maxBackupDataRows = int.MaxValue);
         ICodeFirst SetStringDefaultLength(int length);
+        ICodeFirst SetGuidDefaultLength(int length);
         void InitTables(string entitiesNamespace);
         void InitTables(string[] entitiesNamespaces);
         void InitTables(params Type[] entityTypes);


### PR DESCRIPTION
用于mysql没有 guid类型时,创建表的默认 长度为1的问题。修改默认长度