### PR TITLE
支持数据库中以字符串表示的结构体赋值

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
@@ -241,10 +241,6 @@ namespace SqlSugar
                 case CSharpDataType.@string:
                     CheckType(bind.StringThrow, bindProperyTypeName, validPropertyName, propertyName);
                     method = getString;
-                    if (bindProperyTypeName == "guid")
-                    {
-                        method = isNullableType ? getConvertStringGuid : getStringGuid;
-                    }
                     break;
                 case CSharpDataType.DateTime:
                     CheckType(bind.DateThrow, bindProperyTypeName, validPropertyName, propertyName);
@@ -316,9 +312,14 @@ namespace SqlSugar
             {
                 method = getConvertValueMethod.MakeGenericMethod(bindPropertyType);
             }
-            if (method == null)
+            if (validPropertyType == CSharpDataType.@string && bindPropertyType.IsValueType)
+            {
                 method = isNullableType ? getOtherNull.MakeGenericMethod(bindPropertyType) : getOther.MakeGenericMethod(bindPropertyType);
-
+            }
+            if (method == null)
+            {
+                method = isNullableType ? getOtherNull.MakeGenericMethod(bindPropertyType) : getOther.MakeGenericMethod(bindPropertyType);
+            }
             if (method.IsVirtual)
                 generator.Emit(OpCodes.Callvirt, method);
             else

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
@@ -241,10 +241,6 @@ namespace SqlSugar
                 case CSharpDataType.@string:
                     CheckType(bind.StringThrow, bindProperyTypeName, validPropertyName, propertyName);
                     method = getString;
-                    if (bindProperyTypeName == "guid")
-                    {
-                        method = isNullableType ? getConvertStringGuid : getStringGuid;
-                    }
                     break;
                 case CSharpDataType.DateTime:
                     CheckType(bind.DateThrow, bindProperyTypeName, validPropertyName, propertyName);
@@ -316,9 +312,14 @@ namespace SqlSugar
             {
                 method = getConvertValueMethod.MakeGenericMethod(bindPropertyType);
             }
-            if (method == null)
+            if (validPropertyType == CSharpDataType.@string && bindPropertyType.IsValueType)
+            {
                 method = isNullableType ? getOtherNull.MakeGenericMethod(bindPropertyType) : getOther.MakeGenericMethod(bindPropertyType);
-
+            }
+            if (method == null)
+            {
+                method = isNullableType ? getOtherNull.MakeGenericMethod(bindPropertyType) : getOther.MakeGenericMethod(bindPropertyType);
+            }
             if (method.IsVirtual)
                 generator.Emit(OpCodes.Callvirt, method);
             else


### PR DESCRIPTION
支持数据库中以字符串表示的结构体赋值
如果结构体是框架自带的结构体,可以自动完成赋值,例如Guid类,
如果结构体是自定义的结构体,需要添加对应的TypeConverter子类和TypeConverterAttitude特性