### PR TITLE
解决枚举负数会崩溃的问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataRecordExtensions.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataRecordExtensions.cs
@@ -267,7 +267,7 @@ namespace SqlSugar
             {
                 if (value.GetType() == UtilConstants.DecType)
                 {
-                    value = Convert.ToUInt32(value);
+                    value = Convert.ToInt16(value);
                 }
                 else if (value.GetType() == UtilConstants.StringType)
                 {

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/Oracle/SqlBuilder/OracleQueryBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/Oracle/SqlBuilder/OracleQueryBuilder.cs
@@ -37,7 +37,13 @@ namespace SqlSugar
             string groupByValue = GetGroupByString + HavingInfos;
             string orderByValue = (!isRowNumber && this.OrderByValue.HasValue()) ? GetOrderByString : null;
             if (isIgnoreOrderBy) { orderByValue = null; }
-            sql.AppendFormat(SqlTemplate, GetSelectValue, GetTableNameString, GetWhereValueString, groupByValue, orderByValue);
+            string selectedValue = GetSelectValue;
+            string tableNameString = GetTableNameString;
+            if (selectedValue == "*" && tableNameString.TrimEnd().EndsWith("MergeTable"))
+            {
+                selectedValue = "MergeTable.*";
+            }
+            sql.AppendFormat(SqlTemplate, selectedValue, GetTableNameString, GetWhereValueString, groupByValue, orderByValue);
             sql.Replace(UtilConstants.ReplaceKey, isRowNumber ? (isIgnoreOrderBy ? null : rowNumberString) : null);
             if (isIgnoreOrderBy) { this.OrderByValue = oldOrderBy; return sql.ToString(); }
             var result = ToPageSql(sql.ToString(), this.Take, this.Skip);


### PR DESCRIPTION
枚举类型值为负数读取时导致崩溃
Oracle的情况下，用了MergeTable以后，如果查询不用MergeTable.*会导致SQL出错
可空类型转换判断不对