### PR TITLE
升级 .net 5 后，修复  time 数据库类型 time zone 问题

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
@@ -278,7 +278,7 @@ namespace SqlSugar
                     CheckType(bind.DateThrow, bindProperyTypeName, validPropertyName, propertyName);
                     if (bindProperyTypeName == "datetime")
                         method = isNullableType ? getConvertDateTime : getDateTime;
-                    if (bindProperyTypeName == "datetime" && dbTypeName.ToLower() == "time")
+                    if (bindProperyTypeName == "datetime" && (dbTypeName.ToLower() == "time" || dbTypeName.ToLower() == "time with time zone" || dbTypeName.ToLower() == "time without time zone"))
                         method = isNullableType ? getConvertTime : getTime;
                     if (bindProperyTypeName == "datetimeoffset")
                         method = isNullableType ? getConvertdatetimeoffset : getdatetimeoffset;

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
@@ -278,7 +278,7 @@ namespace SqlSugar
                     CheckType(bind.DateThrow, bindProperyTypeName, validPropertyName, propertyName);
                     if (bindProperyTypeName == "datetime")
                         method = isNullableType ? getConvertDateTime : getDateTime;
-                    if (bindProperyTypeName == "datetime" && dbTypeName.ToLower() == "time")
+                    if (bindProperyTypeName == "datetime" && (dbTypeName.ToLower() == "time" || dbTypeName.ToLower() == "time with time zone" || dbTypeName.ToLower() == "time without time zone"))
                         method = isNullableType ? getConvertTime : getTime;
                     if (bindProperyTypeName == "datetimeoffset")
                         method = isNullableType ? getConvertdatetimeoffset : getdatetimeoffset;


### PR DESCRIPTION
升级 .net 5 后，修复  time 数据库类型 time zone 问题