### PR TITLE
简化异常提示

### DIFF
--- a/Src/Asp.Net/SqlSugar/Utilities/ErrorMessage.cs
+++ b/Src/Asp.Net/SqlSugar/Utilities/ErrorMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 namespace SqlSugar
@@ -41,12 +42,12 @@ namespace SqlSugar
             }
         }
 
-        internal static string GetThrowMessage(string enMessage, string cnMessage, params string[] args)
+        internal static string GetThrowMessage(string enMessage, string cnMessage)
         {
-            List<string> formatArgs = new List<string>() { enMessage, cnMessage };
-            formatArgs.AddRange(args);
-            return string.Format(@"English Message : {0}
-Chinese Message : {1}", formatArgs.ToArray());
+            if (CultureInfo.CurrentCulture.Name.StartsWith("zh"))
+                return cnMessage;
+            else
+                return enMessage;
         }
     }
 }


### PR DESCRIPTION
在GetThrowMessage中根据CurrentCulture返回enMessage或cnMessage，删除其args参数（因为没有用到过且没有意义）
http://www.donet5.com/Ask/14/13415