### PR TITLE
fix the dbtype resolve error when using pg

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MethodCallExpressionResolve.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MethodCallExpressionResolve.cs
@@ -563,6 +563,8 @@ namespace SqlSugar
                     type = DbType.Sqlite;
                 else if (this.Context is OracleExpressionContext)
                     type = DbType.Oracle;
+                else if (this.Context is PostgreSQLExpressionContext)
+                    type = DbType.PostgreSQL;
                 return this.Context.SqlFuncServices.First(it => it.UniqueMethodName == name).MethodValue(model, type, this.Context);
             }
             else


### PR DESCRIPTION
when using pg database, the dbtype will be recolved as sql server by mistake.
fix the error.