### PR TITLE
解决codefirst 类似这样ColumnDataType = "uniqueidentifier,varchar(36)" 设置的bug

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
@@ -92,6 +92,22 @@ namespace SqlSugar
             var types = Assembly.Load(entitiesNamespace).GetTypes();
             InitTables(types);
         }
+
+        public virtual void InitTables(string assemblyName, string entitiesNamespace)
+        {
+            var types = Assembly.Load(assemblyName).GetTypes().Where(t => t.Namespace == entitiesNamespace).ToArray();
+            InitTables(types);
+        }
+
+        public virtual void InitTables(Dictionary<string, string> namespaces)
+        {
+            foreach (var keyValueNamespace in namespaces)
+            {
+                var types = Assembly.Load(keyValueNamespace.Key).GetTypes().Where(t => t.Namespace == keyValueNamespace.Value).ToArray();
+                InitTables(types);
+            }
+        }
+
         public virtual void InitTables(params string[] entitiesNamespaces)
         {
             if (entitiesNamespaces.HasValue())

--- a/Src/Asp.Net/SqlSugar/Interface/ICodeFirst.cs
+++ b/Src/Asp.Net/SqlSugar/Interface/ICodeFirst.cs
@@ -10,6 +10,8 @@ namespace SqlSugar
         ICodeFirst BackupTable(int maxBackupDataRows = int.MaxValue);
         ICodeFirst SetStringDefaultLength(int length);
         void InitTables(string entitiesNamespace);
+        void InitTables(string assemblyName, string entitiesNamespace);
+        void InitTables(Dictionary<string, string> namespaces);
         void InitTables(string[] entitiesNamespaces);
         void InitTables(params Type[] entityTypes);
         void InitTables(Type entityType);

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
@@ -120,10 +120,19 @@ namespace SqlSugar
                     {
                         var types = item.DataType.Split(',').Select(it => it.ToLower()).ToList();
                         var mapingTypes=this.Context.Ado.DbBind.MappingTypes.Select(it=>it.Key.ToLower()).ToList();
-                        var mappingType = types.FirstOrDefault(it => mapingTypes.Any(it.StartsWith));
+                        // var mappingType = types.FirstOrDefault(it => mapingTypes.Any(it.StartsWith));
+                        var mappingType = types.FirstOrDefault(it => mapingTypes.Contains(it));
                         if (mappingType != null) 
                         {
                             item.DataType = mappingType;
+                        }
+                        else
+                        {
+                            mappingType = types.FirstOrDefault(it => mapingTypes.Any(it.StartsWith));
+                            if (mappingType != null)
+                            {
+                                item.DataType = mappingType;
+                            }
                         }
                     }
                 }

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
@@ -102,6 +102,20 @@ namespace SqlSugar
                 }
             }
         }
+
+        public virtual void InitTables(string assemblyName, string entitiesNamespace)
+        {
+            var types = Assembly.Load(assemblyName).GetTypes().Where(t => t.Namespace == entitiesNamespace).ToArray();
+            InitTables(types);
+        }
+
+        public virtual void InitTables(Dictionary<string, string> namespaces)
+        {
+            foreach (var keyValueNamespace in namespaces)
+            {
+                InitTables(keyValueNamespace.Key, keyValueNamespace.Value);
+            }
+        }
         #endregion
 
         #region Core Logic

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
@@ -120,7 +120,7 @@ namespace SqlSugar
                     {
                         var types = item.DataType.Split(',').Select(it => it.ToLower()).ToList();
                         var mapingTypes=this.Context.Ado.DbBind.MappingTypes.Select(it=>it.Key.ToLower()).ToList();
-                        var mappingType=types.FirstOrDefault(it => mapingTypes.Contains(it));
+                        var mappingType = types.FirstOrDefault(it => mapingTypes.Any(it.StartsWith));
                         if (mappingType != null) 
                         {
                             item.DataType = mappingType;

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/DbBindAccessory.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/DbBindAccessory.cs
@@ -218,7 +218,7 @@ namespace SqlSugar
         private static void GetValueTypeList<T>(Type type, IDataReader dataReader, List<T> result)
         {
             var value = dataReader.GetValue(0);
-            if (type == UtilConstants.GuidType)
+            if (type == UtilConstants.GuidType || type == UtilConstants.GuidTypeNull)
             {
                 value = Guid.Parse(value.ToString());
             }

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/Common/SugarParameter.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/Common/SugarParameter.cs
@@ -14,6 +14,7 @@ namespace SqlSugar
         {
             this.Value = value;
             this.ParameterName = name;
+            this.Direction = ParameterDirection.Input;
             if (value != null)
             {
                 SettingDataType(value.GetType());
@@ -23,6 +24,7 @@ namespace SqlSugar
         {
             this.Value = value;
             this.ParameterName = name;
+            this.Direction = ParameterDirection.Input;
             SettingDataType(type);
         }
         public SugarParameter(string name, object value, Type type, ParameterDirection direction)
@@ -47,12 +49,14 @@ namespace SqlSugar
             this.Value = value;
             this.ParameterName = name;
             this.DbType = type;
+            this.Direction = ParameterDirection.Input;
         }
         public SugarParameter(string name, DataTable value, string SqlServerTypeName)
         {
             this.Value = value;
             this.ParameterName = name;
             this.TypeName = SqlServerTypeName;
+            this.Direction = ParameterDirection.Input;
         }
         public SugarParameter(string name, object value, System.Data.DbType type, ParameterDirection direction)
         {

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Interface/ICodeFirst.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Interface/ICodeFirst.cs
@@ -11,6 +11,8 @@ namespace SqlSugar
         ICodeFirst SetStringDefaultLength(int length);
         void InitTables(string entitiesNamespace);
         void InitTables(string[] entitiesNamespaces);
+        void InitTables(string assemblyName, string entitiesNamespace);
+        void InitTables(Dictionary<string, string> namespaces);
         void InitTables(params Type[] entityTypes);
         void InitTables(Type entityType);
         void InitTables<T>();

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/OnlyCore/DataExtensions.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/OnlyCore/DataExtensions.cs
@@ -11,6 +11,8 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
 namespace SqlSugar
 {
 

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/SqlServer/DbBind/SqlServerDbBind.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/SqlServer/DbBind/SqlServerDbBind.cs
@@ -25,7 +25,9 @@ namespace SqlSugar
                 {
                   new KeyValuePair<string, CSharpDataType>("int",CSharpDataType.@int),
                   new KeyValuePair<string, CSharpDataType>("varchar",CSharpDataType.@string),
+                  new KeyValuePair<string, CSharpDataType>("varchar(max)",CSharpDataType.@string),
                   new KeyValuePair<string, CSharpDataType>("nvarchar",CSharpDataType.@string),
+                  new KeyValuePair<string, CSharpDataType>("nvarchar(max)",CSharpDataType.@string),
                   new KeyValuePair<string, CSharpDataType>("sql_variant",CSharpDataType.@string),
                   new KeyValuePair<string, CSharpDataType>("text",CSharpDataType.@string),
                   new KeyValuePair<string, CSharpDataType>("char",CSharpDataType.@string),

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/SqlServer/SqlBuilder/SqlServerBlueCopy.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/SqlServer/SqlBuilder/SqlServerBlueCopy.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace SqlSugar 
 {

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/SqlServer/SqlServerProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/SqlServer/SqlServerProvider.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
 namespace SqlSugar
 {
     public class SqlServerProvider : AdoProvider

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/SqlSugar.csproj
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/SqlSugar.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="MySql.Data" Version="8.0.21" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
@@ -28,7 +29,6 @@
     <PackageReference Include="SqlSugarCore.Dm" Version="1.0.0" />
     <PackageReference Include="SqlSugarCore.Kdbndp" Version="1.0.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Utilities/UtilConstants.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Utilities/UtilConstants.cs
@@ -18,6 +18,7 @@ namespace SqlSugar
         internal static Type IntType = typeof(int);
         internal static Type LongType = typeof(long);
         internal static Type GuidType = typeof(Guid);
+        internal static Type GuidTypeNull = typeof(Guid?);
         internal static Type BoolType = typeof(bool);
         internal static Type BoolTypeNull = typeof(bool?);
         internal static Type ByteType = typeof(Byte);


### PR DESCRIPTION
原来的代码匹配类型的时候没考虑带长度的问题，因此类型一致无法匹配