### PR TITLE
Update MySqlDbMaintenance.cs

### DIFF
--- a/Src/Asp.Net/SqlSugar/Realization/MySql/DbMaintenance/MySqlDbMaintenance.cs
+++ b/Src/Asp.Net/SqlSugar/Realization/MySql/DbMaintenance/MySqlDbMaintenance.cs
@@ -289,7 +289,7 @@ namespace SqlSugar
             }
             var oldDatabaseName = this.Context.Ado.Connection.Database;
             var connection = this.Context.CurrentConnectionConfig.ConnectionString;
-            connection = connection.Replace(oldDatabaseName, "mysql");
+            connection = connection.Replace($"database={oldDatabaseName}", "database=mysql");
             var newDb = new SqlSugarClient(new ConnectionConfig()
             {
                 DbType = this.Context.CurrentConnectionConfig.DbType,


### PR DESCRIPTION
添加替换限定，确保不会把用户名也一起替换掉。

如果数据库名字和用户名有重叠部分，用户名就会被一起错误的替换掉，导致连接不上数据库。

例如连接字符串：
`server=127.0.0.1;database=test;uid=test;pwd=secret;charset=utf8mb4;`

由于用户名被替换，所以报错如下：
![Screenshot_20210815_001400](https://user-images.githubusercontent.com/20024328/129452601-f566b96f-d263-470a-b88a-82abba08f71d.png)


