### PR TITLE
Add check for columns‘s’ type in  GetIdentityKey()

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
@@ -702,6 +702,9 @@ namespace SqlSugar
             }
             else
             {
+                Check.Exception(this.EntityInfo.Columns.Where(it => it.IsIdentity
+                && it.UnderType == typeof(string)).ToList().Count > 0,
+                    "IsIdentity key can not be type of string");
                 return this.EntityInfo.Columns.Where(it => it.IsIdentity).Select(it => it.DbColumnName).ToList();
             }
         }


### PR DESCRIPTION
IdentityKey can not be type of string. ExecuteReturnEntity() and ExecuteCommandIdentityIntoEntity() will throw exception with "IsIdentity key can not be type of string" when Key filed signed with [IsIdentity = true] ,instead of "DBNULL can not cast to int64" at Convert.ToInt64(Ado.GetScalar(sql, InsertBuilder.Parameters == null ? null : InsertBuilder.Parameters.ToArray()))