### PR TITLE
Postgresql Fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+Src/Asp.NetCore2/SqlSeverTest/.idea/

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DeleteProvider/DeleteableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DeleteProvider/DeleteableProvider.cs
@@ -520,10 +520,13 @@ namespace SqlSugar
                     item.Columns = new List<DiffLogColumnInfo>();
                     foreach (DataColumn col in dt.Columns)
                     {
+                        var sugarColumn = this.EntityInfo.Columns.Where(it => it.DbColumnName != null).First(it =>
+                            it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase));
                         DiffLogColumnInfo addItem = new DiffLogColumnInfo();
                         addItem.Value = row[col.ColumnName];
                         addItem.ColumnName = col.ColumnName;
-                        addItem.ColumnDescription = this.EntityInfo.Columns.Where(it=>it.DbColumnName!=null).First(it => it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase)).ColumnDescription;
+                        addItem.IsPrimaryKey = sugarColumn.IsPrimarykey;
+                        addItem.ColumnDescription = sugarColumn.ColumnDescription;
                         item.Columns.Add(addItem);
                     }
                     result.Add(item);

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
@@ -809,11 +809,13 @@ namespace SqlSugar
                 item.Columns = new List<DiffLogColumnInfo>();
                 foreach (DataColumn col in dt2.Columns)
                 {
-
+                    var sugarColumn = this.EntityInfo.Columns.Where(it => it.DbColumnName != null).FirstOrDefault(it =>
+                        it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase));
                     DiffLogColumnInfo addItem = new DiffLogColumnInfo();
                     addItem.Value = row[col.ColumnName];
                     addItem.ColumnName = col.ColumnName;
-                    addItem.ColumnDescription = this.EntityInfo.Columns.Where(it => it.DbColumnName != null).FirstOrDefault(it => it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase))?.ColumnDescription;
+                    addItem.IsPrimaryKey = sugarColumn?.IsPrimarykey ?? false;
+                    addItem.ColumnDescription = sugarColumn?.ColumnDescription;
                     item.Columns.Add(addItem);
                 }
                 result.Add(item);
@@ -830,7 +832,16 @@ namespace SqlSugar
             if (identity != null && identity > 0 && GetIdentityKeys().HasValue())
             {
                 var fieldName = GetIdentityKeys().Last();
-                cons.Add(new ConditionalModel() { ConditionalType = ConditionalType.Equal, FieldName = fieldName, FieldValue = identity.ToString() });
+
+                if (this.Context.CurrentConnectionConfig.DbType == DbType.PostgreSQL)
+                {
+                    var fieldObjectType = this.EntityInfo.Columns.FirstOrDefault(x => x.DbColumnName == fieldName)
+                        .PropertyInfo.PropertyType;
+                    cons.Add(new ConditionalModel() { ConditionalType = ConditionalType.Equal, FieldName = fieldName, FieldValue = identity.ToString(), 
+                        FieldValueConvertFunc = it => UtilMethods.ChangeType2(it, fieldObjectType) });
+                }
+                else
+                    cons.Add(new ConditionalModel() { ConditionalType = ConditionalType.Equal, FieldName = fieldName, FieldValue = identity.ToString() });
             }
             else
             {
@@ -864,10 +875,13 @@ namespace SqlSugar
                     item.Columns = new List<DiffLogColumnInfo>();
                     foreach (DataColumn col in dt.Columns)
                     {
+                        var sugarColumn = this.EntityInfo.Columns.Where(it => it.DbColumnName != null).First(it =>
+                            it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase));
                         DiffLogColumnInfo addItem = new DiffLogColumnInfo();
                         addItem.Value = row[col.ColumnName];
                         addItem.ColumnName = col.ColumnName;
-                        addItem.ColumnDescription = this.EntityInfo.Columns.Where(it => it.DbColumnName != null).First(it => it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase)).ColumnDescription;
+                        addItem.IsPrimaryKey = sugarColumn.IsPrimarykey;
+                        addItem.ColumnDescription = sugarColumn.ColumnDescription;
                         item.Columns.Add(addItem);
                     }
                     result.Add(item);
@@ -883,7 +897,8 @@ namespace SqlSugar
                 {
                     ColumnDescription = it.ColumnDescription,
                     ColumnName = it.DbColumnName,
-                    Value = it.PropertyInfo.GetValue(this.InsertObjs.Last(), null)
+                    Value = it.PropertyInfo.GetValue(this.InsertObjs.Last(), null),
+                    IsPrimaryKey = it.IsPrimarykey
                 }).ToList();
                 return new List<DiffLogTableInfo>() { diffTable };
             }

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
@@ -840,10 +840,13 @@ namespace SqlSugar
                     item.Columns = new List<DiffLogColumnInfo>();
                     foreach (DataColumn col in dt.Columns)
                     {
+                        var sugarColumn = this.EntityInfo.Columns.Where(it => it.DbColumnName != null).First(it =>
+                            it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase));
                         DiffLogColumnInfo addItem = new DiffLogColumnInfo();
                         addItem.Value = row[col.ColumnName];
                         addItem.ColumnName = col.ColumnName;
-                        addItem.ColumnDescription = this.EntityInfo.Columns.Where(it => it.DbColumnName != null).First(it => it.DbColumnName.Equals(col.ColumnName, StringComparison.CurrentCultureIgnoreCase)).ColumnDescription;
+                        addItem.IsPrimaryKey = sugarColumn.IsPrimarykey;
+                        addItem.ColumnDescription = sugarColumn.ColumnDescription;
                         item.Columns.Add(addItem);
                     }
                     result.Add(item);

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Entities/DiffLogModel.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Entities/DiffLogModel.cs
@@ -21,10 +21,11 @@ namespace SqlSugar
         public string TableDescription { get; set; }
         public List<DiffLogColumnInfo> Columns { get; set; }
     }
-    public class DiffLogColumnInfo {
-
+    public class DiffLogColumnInfo 
+    {
         public string ColumnName { get; set; }
         public string ColumnDescription { get; set; }
         public object Value { get; set; }
+        public bool IsPrimaryKey { get; set; }
     }
 }

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/PostgreSQL/Insertable/PostgreSQLInserttable.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Realization/PostgreSQL/Insertable/PostgreSQLInserttable.cs
@@ -16,6 +16,7 @@ namespace SqlSugar
             string sql = InsertBuilder.ToSqlString().Replace("$PrimaryKey",this.SqlBuilder.GetTranslationColumnName(GetIdentityKeys().FirstOrDefault()));
             RestoreMapping();
             var result = Ado.GetScalar(sql, InsertBuilder.Parameters == null ? null : InsertBuilder.Parameters.ToArray()).ObjToInt();
+            After(sql, result);
             return result;
         }
         public override async Task<int> ExecuteReturnIdentityAsync()
@@ -26,6 +27,7 @@ namespace SqlSugar
             RestoreMapping();
             var obj = await Ado.GetScalarAsync(sql, InsertBuilder.Parameters == null ? null : InsertBuilder.Parameters.ToArray());
             var result = obj.ObjToInt();
+            After(sql, result);
             return result;
         }
         public override KeyValuePair<string, List<SugarParameter>> ToSql()
@@ -41,6 +43,7 @@ namespace SqlSugar
             string sql = InsertBuilder.ToSqlString().Replace("$PrimaryKey", this.SqlBuilder.GetTranslationColumnName(GetIdentityKeys().FirstOrDefault()));
             RestoreMapping();
             var result = Convert.ToInt64(Ado.GetScalar(sql, InsertBuilder.Parameters == null ? null : InsertBuilder.Parameters.ToArray()) ?? "0");
+            After(sql, result);
             return result;
         }
         public override async Task<long> ExecuteReturnBigIdentityAsync()
@@ -50,6 +53,7 @@ namespace SqlSugar
             string sql = InsertBuilder.ToSqlString().Replace("$PrimaryKey", this.SqlBuilder.GetTranslationColumnName(GetIdentityKeys().FirstOrDefault()));
             RestoreMapping();
             var result = Convert.ToInt64(await Ado.GetScalarAsync(sql, InsertBuilder.Parameters == null ? null : InsertBuilder.Parameters.ToArray()) ?? "0");
+            After(sql, result);
             return result;
         }
 

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/SqlSugar.csproj
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/SqlSugar.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="MySql.Data" Version="8.0.21" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Npgsql" Version="4.1.3.1" />
+    <PackageReference Include="Npgsql" Version="6.0.2" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.1" />
     <PackageReference Include="Oscar.Data.SqlClient" Version="4.0.4" />
     <PackageReference Include="SqlSugarCore.Dm" Version="1.0.0" />


### PR DESCRIPTION
Changes mostly focused on audit feature.
- Npgsql version update the reason for the change is older version there is an unimplemented method which throws exception.
- AfterData method calls added to PostgresqlInsertableProvider to fire OnDiffLogEvent event.
- IsPrimaryKey added to get information of changed entity's Id which is required to keep track of audit trails.