### PR TITLE
IsJson, IsArray, SqlQueryable sub queriable fixes.

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Abstract/SqlBuilderProvider/QueryBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/SqlBuilderProvider/QueryBuilder.cs
@@ -652,7 +652,7 @@ namespace SqlSugar
                     result = result.Replace(" ) unionTable  ", ") "+TableShortName + UtilConstants.Space);
                     TableShortName = null;
                 }
-                if (this.TableShortName.HasValue())
+                if (this.TableShortName.HasValue() && !this.IsSqlQuery)
                 {
                     result += (TableShortName + UtilConstants.Space);
                 }

--- a/Src/Asp.NetCore2/SqlSugar/Abstract/SugarProvider/SqlSugarAccessory.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/SugarProvider/SqlSugarAccessory.cs
@@ -199,7 +199,9 @@ namespace SqlSugar
                         OldDbColumnName = item.OldDbColumnName,
                         OracleSequenceName = item.OracleSequenceName,
                         PropertyInfo = item.PropertyInfo,
-                        PropertyName = item.PropertyName
+                        PropertyName = item.PropertyName,
+                        IsJson = item.IsJson,
+                        IsArray = item.IsArray
                     };
                     columns.Add(item);
                 }

--- a/Src/Asp.NetCore2/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
@@ -333,6 +333,10 @@ namespace SqlSugar
                     {
                         value = value.Replace("= \"SYSDATE\"", "= SYSDATE");
                     }
+                    var param = UpdateBuilder.Parameters.First(x => x.ParameterName == item.Split(" = ")[1].Trim());
+                    var columnInfo = UpdateBuilder.DbColumnInfoList.First(x => x.DbColumnName == key);
+                    param.IsArray = columnInfo.IsArray;
+                    param.IsJson = columnInfo.IsJson;
                     UpdateBuilder.SetValues.Add(new KeyValuePair<string, string>(SqlBuilder.GetTranslationColumnName(key), value));
                 }
             }


### PR DESCRIPTION
- IsJson and IsArray property values were not being tracked in UpdateableProvider context. Added property mappings to CopyEntityInfo and SetColumn methods.

- Wrapped by "select t* from () as t" SqlQuerable queries that contain SqlFunc.Subqueryable in Where condition were generating wrong table name. 