### PR TITLE
1、解决SqliteDbMaintenance.GetColumnInfosByTableName方法没有取得小数长度

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/OnlyCore/DataExtensions.cs
+++ b/Src/Asp.NetCore2/SqlSugar/OnlyCore/DataExtensions.cs
@@ -424,7 +424,14 @@ namespace SqlSugar
                         DataRow daRow = dt.NewRow();
                         for (int i = 0; i < columns.Count; i++)
                         {
+                            if (columns[i].DataType == System.Type.GetType("System.Byte[]"))
+                            {
+                                daRow[columns[i].ColumnName] = System.Text.Encoding.ASCII.GetBytes(dr.GetValue(i).ToString());
+                            }
+                            else
+                            {
                             daRow[columns[i].ColumnName] = dr.GetValue(i);
+                            }
                         }
                         dt.Rows.Add(daRow);
                     }

--- a/Src/Asp.NetCore2/SqlSugar/Realization/Sqlite/DbMaintenance/SqliteDbMaintenance.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/Sqlite/DbMaintenance/SqliteDbMaintenance.cs
@@ -311,10 +311,20 @@ namespace SqlSugar
                 {
                     var type = dataReader.GetValue(2).ObjToString();
                     var length = 0;
+                    var decimalDigits = 0;
                     if (type.Contains("("))
                     {
-                        type = type.Split('(').First();
+                        if (type.Contains(","))
+                        {
+                            var digit = type.Split('(').Last().TrimEnd(')');
+                            decimalDigits = digit.Split(',').Last().ObjToInt();
+                            length = digit.Split(',').First().ObjToInt();
+                        }
+                        else
+                        {
                         length = type.Split('(').Last().TrimEnd(')').ObjToInt();
+                        }
+                        type = type.Split('(').First();
                     }
                     bool isIdentity = columns.FirstOrDefault(it => it.DbColumnName.Equals(dataReader.GetString(1),StringComparison.CurrentCultureIgnoreCase)).IsIdentity;
                     DbColumnInfo column = new DbColumnInfo()


### PR DESCRIPTION
2、解决SqliteDataAdapter.Fill(DataSet ds)方法对System.Byte[]的填充未判断