### PR TITLE
Update UpdateNavManyToMany.cs

### DIFF
--- a/Src/Asp.NetCore2/SqlSugar/Abstract/ExecuteNavProvider/UpdateNavManyToMany.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/ExecuteNavProvider/UpdateNavManyToMany.cs
@@ -28,6 +28,7 @@ namespace SqlSugar
                    .Where(it => it.IsPrimarykey && !it.IsIdentity && it.OracleSequenceName.IsNullOrEmpty()).FirstOrDefault();
             Check.Exception(mappingA == null || mappingB == null, $"Navigate property {name} error ", $"导航属性{name}配置错误");
             List<Dictionary<string, object>> mappgingTables = new List<Dictionary<string, object>>();
+            var ids=new List<object>();
             foreach (var item in parentList)
             {
                 var items = parentNavigateProperty.PropertyInfo.GetValue(item);
@@ -41,6 +42,10 @@ namespace SqlSugar
                     _ParentList = children.Cast<object>().ToList();
                 }
                 var parentId = parentPkColumn.PropertyInfo.GetValue(item);
+                if (!ids.Contains(parentId))
+                {
+                    ids.Add(parentId);
+                }
                 foreach (var child in children)
                 {
                     var chidId = thisPkColumn.PropertyInfo.GetValue(child);
@@ -54,7 +59,6 @@ namespace SqlSugar
                     mappgingTables.Add(keyValuePairs);
                 }
             }
-            var ids = mappgingTables.Select(x => x[mappingA.DbColumnName]).ToList();
             this._Context.Deleteable<object>().AS(mappingEntity.DbTableName).In(mappingA.DbColumnName, ids).ExecuteCommand();
             this._Context.Insertable(mappgingTables).AS(mappingEntity.DbTableName).ExecuteCommand();
             _ParentEntity = thisEntity;


### PR DESCRIPTION
修复：多对多关联更新时无法清空主体实体对应的中间表记录。

问题重现(book.Authors.Count==0时映射中间表book_author_rel对应bookId记录无法清空)：
`await _db.UpdateNav<Book>(item) .Include(x => x.Authors) .ExecuteCommandAsync();`