### PR TITLE
fix: when default value is date, double quote appear

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/DbMaintenanceProvider/Methods.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/DbMaintenanceProvider/Methods.cs
@@ -378,7 +378,7 @@ namespace SqlSugar
             {
                 defaultValue = "";
             }
-            if (defaultValue.IsDate()) 
+            if (defaultValue.IsDate() && !AddDefaultValueSql.Contains("'{2}'")) 
             {
                 defaultValue = "'" + defaultValue + "'";
             }


### PR DESCRIPTION
当Date类型默认值时，出现双引号，因AddDefaultValueSql配置的模板语法不同，添加一个修复判断。