### PR TITLE
Mysql创建表时，增加字段注释。

### DIFF
--- a/Src/Asp.NetCore2/MySqlTest/Models/Order.cs
+++ b/Src/Asp.NetCore2/MySqlTest/Models/Order.cs
@@ -11,8 +11,9 @@ namespace OrmTest
     {
         [SugarColumn(IsPrimaryKey = true, IsIdentity = true)]
         public int Id { get; set; }
-
+        [SugarColumn(ColumnDescription ="名称")]
         public string Name { get; set; }
+        [SugarColumn(ColumnDescription = "价格")]
         public decimal Price { get; set; }
         [SugarColumn(IsNullable = true)]
         public DateTime CreateTime { get; set; }

--- a/Src/Asp.NetCore2/SqlSugar/Realization/MySql/DbMaintenance/MySqlDbMaintenance.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/MySql/DbMaintenance/MySqlDbMaintenance.cs
@@ -392,6 +392,10 @@ namespace SqlSugar
                 string primaryKey = null;
                 string identity = item.IsIdentity ? this.CreateTableIdentity : null;
                 string addItem = string.Format(this.CreateTableColumn, this.SqlBuilder.GetTranslationColumnName(columnName), dataType, dataSize, nullType, primaryKey, identity);
+                if (!string.IsNullOrEmpty(item.ColumnDescription))
+                {
+                    addItem += "COMMENT '"+item.ColumnDescription+"' ";
+                }
                 columnArray.Add(addItem);
             }
             string tableString = string.Format(this.CreateTableSql, this.SqlBuilder.GetTranslationTableName(tableName), string.Join(",\r\n", columnArray));


### PR DESCRIPTION
mysql建表时，注释在字段信息里。修复了原来建表，注释没有加到表上的问题。