### PR TITLE
修改QuestDB数据库时获取服务器时间为当前时区时间

### DIFF
--- a/Src/Asp.Net/SqlSugar/Realization/QuestDB/SqlBuilder/QuestDBBuilder.cs
+++ b/Src/Asp.Net/SqlSugar/Realization/QuestDB/SqlBuilder/QuestDBBuilder.cs
@@ -24,21 +24,39 @@ namespace SqlSugar
         {
             get
             {
-                return "now()";
+                //https://questdb.io/docs/guides/working-with-timestamps-timezones/#using-utc-offset-for-conversions
+                //https://questdb.io/docs/reference/function/date-time/#to_timezone
+                //SELECT 
+                //      now(),  --2022-10-21T07:19:50.680134Z
+                //      systimestamp(), --2022-10-21T07:19:50.680278Z
+                //      sysdate(), --2022-10-21T07:19:50.679Z
+                //      to_timezone(NOW(), 'Asia/ShangHai'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(), 'HKT'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(),'+08') --2022-10-21T15:19:50.680134Z
+                return $"to_timezone(NOW(),'{TimeZoneInfo.Local.BaseUtcOffset.Hours:00}')";
             }
         }
         public override string FullSqlDateNow
         {
             get
             {
-                return "select now()";
+                //https://questdb.io/docs/guides/working-with-timestamps-timezones/#using-utc-offset-for-conversions
+                //https://questdb.io/docs/reference/function/date-time/#to_timezone
+                //SELECT 
+                //      now(),  --2022-10-21T07:19:50.680134Z
+                //      systimestamp(), --2022-10-21T07:19:50.680278Z
+                //      sysdate(), --2022-10-21T07:19:50.679Z
+                //      to_timezone(NOW(), 'Asia/ShangHai'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(), 'HKT'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(),'+08') --2022-10-21T15:19:50.680134Z
+                return $"SELECT to_timezone(NOW(),'{TimeZoneInfo.Local.BaseUtcOffset.Hours:00}')";
             }
         }
 
         public bool isAutoToLower => false;
         public override string GetTranslationColumnName(string propertyName)
         {
-            if (propertyName.Contains(".")&& !propertyName.Contains(SqlTranslationLeft)) 
+            if (propertyName.Contains(".") && !propertyName.Contains(SqlTranslationLeft))
             {
                 return string.Join(".", propertyName.Split('.').Select(it => $"{SqlTranslationLeft}{it.ToLower(isAutoToLower)}{SqlTranslationRight}"));
             }
@@ -74,7 +92,7 @@ namespace SqlSugar
                 .MappingTables
                 .FirstOrDefault(it => it.EntityName.Equals(name, StringComparison.CurrentCultureIgnoreCase));
             name = (mappingInfo == null ? name : mappingInfo.DbTableName);
-            if (name.Contains(".")&& !name.Contains("(")&&!name.Contains("\".\""))
+            if (name.Contains(".") && !name.Contains("(") && !name.Contains("\".\""))
             {
                 return string.Join(".", name.ToLower(isAutoToLower).Split('.').Select(it => SqlTranslationLeft + it + SqlTranslationRight));
             }

--- a/Src/Asp.NetCore2/SqlSugar/Realization/QuestDB/SqlBuilder/QuestDBBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/QuestDB/SqlBuilder/QuestDBBuilder.cs
@@ -24,21 +24,37 @@ namespace SqlSugar
         {
             get
             {
-                return "now()";
+                //https://questdb.io/docs/reference/function/date-time/#to_timezone
+                //SELECT 
+                //      now(),  --2022-10-21T07:19:50.680134Z
+                //      systimestamp(), --2022-10-21T07:19:50.680278Z
+                //      sysdate(), --2022-10-21T07:19:50.679Z
+                //      to_timezone(NOW(), 'Asia/ShangHai'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(), 'HKT'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(),'+08') --2022-10-21T15:19:50.680134Z
+                return $"to_timezone(NOW(),'{TimeZoneInfo.Local.BaseUtcOffset.Hours:00}')";
             }
         }
         public override string FullSqlDateNow
         {
             get
             {
-                return "select now()";
+                //https://questdb.io/docs/reference/function/date-time/#to_timezone
+                //SELECT 
+                //      now(),  --2022-10-21T07:19:50.680134Z
+                //      systimestamp(), --2022-10-21T07:19:50.680278Z
+                //      sysdate(), --2022-10-21T07:19:50.679Z
+                //      to_timezone(NOW(), 'Asia/ShangHai'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(), 'HKT'), --2022-10-21T15:19:50.680134Z
+                //      to_timezone(NOW(),'+08') --2022-10-21T15:19:50.680134Z
+                return $"SELECT to_timezone(NOW(),'{TimeZoneInfo.Local.BaseUtcOffset.Hours:00}')";
             }
         }
 
         public bool isAutoToLower => false;
         public override string GetTranslationColumnName(string propertyName)
         {
-            if (propertyName.Contains(".")&& !propertyName.Contains(SqlTranslationLeft)) 
+            if (propertyName.Contains(".") && !propertyName.Contains(SqlTranslationLeft))
             {
                 return string.Join(".", propertyName.Split('.').Select(it => $"{SqlTranslationLeft}{it.ToLower(isAutoToLower)}{SqlTranslationRight}"));
             }
@@ -74,7 +90,7 @@ namespace SqlSugar
                 .MappingTables
                 .FirstOrDefault(it => it.EntityName.Equals(name, StringComparison.CurrentCultureIgnoreCase));
             name = (mappingInfo == null ? name : mappingInfo.DbTableName);
-            if (name.Contains(".")&& !name.Contains("(")&&!name.Contains("\".\""))
+            if (name.Contains(".") && !name.Contains("(") && !name.Contains("\".\""))
             {
                 return string.Join(".", name.ToLower(isAutoToLower).Split('.').Select(it => SqlTranslationLeft + it + SqlTranslationRight));
             }

--- a/Src/Asp.NetCore2/SqlSugar/Realization/QuestDB/SqlBuilder/QuestDBBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Realization/QuestDB/SqlBuilder/QuestDBBuilder.cs
@@ -24,6 +24,7 @@ namespace SqlSugar
         {
             get
             {
+                //https://questdb.io/docs/guides/working-with-timestamps-timezones/#using-utc-offset-for-conversions
                 //https://questdb.io/docs/reference/function/date-time/#to_timezone
                 //SELECT 
                 //      now(),  --2022-10-21T07:19:50.680134Z
@@ -39,6 +40,7 @@ namespace SqlSugar
         {
             get
             {
+                //https://questdb.io/docs/guides/working-with-timestamps-timezones/#using-utc-offset-for-conversions
                 //https://questdb.io/docs/reference/function/date-time/#to_timezone
                 //SELECT 
                 //      now(),  --2022-10-21T07:19:50.680134Z


### PR DESCRIPTION
QuestDB数据库获取当前时间，默认是UTC时间，修改为获取当前时区时间