### PR TITLE
修复InsertReturnIdentity由于主键是ushort/short导致的异常

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
@@ -246,7 +246,6 @@ namespace SqlSugar
                 var snowColumn = this.EntityInfo.Columns.FirstOrDefault(it => it.IsPrimarykey && it.UnderType == UtilConstants.LongType);
                 if (snowColumn!=null)
                 {
-              ;
                     if (Convert.ToInt64(snowColumn.PropertyInfo.GetValue(result)) == 0)
                     {
                         var id = this.ExecuteReturnSnowflakeId();
@@ -276,6 +275,14 @@ namespace SqlSugar
             else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ulong)))
             {
                 setValue = Convert.ToUInt64(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ushort)))
+            {
+                setValue = Convert.ToUInt16(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(short)))
+            {
+                setValue = Convert.ToInt16(idValue);
             }
             else
                 setValue = Convert.ToInt32(idValue);
@@ -369,6 +376,14 @@ namespace SqlSugar
             else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ulong)))
             {
                 setValue = Convert.ToUInt64(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ushort)))
+            {
+                setValue = Convert.ToUInt16(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(short)))
+            {
+                setValue = Convert.ToInt16(idValue);
             }
             else
                 setValue = Convert.ToInt32(idValue);

--- a/Src/Asp.NetCore2/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
@@ -246,7 +246,6 @@ namespace SqlSugar
                 var snowColumn = this.EntityInfo.Columns.FirstOrDefault(it => it.IsPrimarykey && it.UnderType == UtilConstants.LongType);
                 if (snowColumn!=null)
                 {
-              ;
                     if (Convert.ToInt64(snowColumn.PropertyInfo.GetValue(result)) == 0)
                     {
                         var id = this.ExecuteReturnSnowflakeId();
@@ -276,6 +275,14 @@ namespace SqlSugar
             else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ulong)))
             {
                 setValue = Convert.ToUInt64(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ushort)))
+            {
+                setValue = Convert.ToUInt16(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(short)))
+            {
+                setValue = Convert.ToInt16(idValue);
             }
             else
                 setValue = Convert.ToInt32(idValue);
@@ -369,6 +376,14 @@ namespace SqlSugar
             else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ulong)))
             {
                 setValue = Convert.ToUInt64(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(ushort)))
+            {
+                setValue = Convert.ToUInt16(idValue);
+            }
+            else if (this.EntityInfo.Columns.Any(it => it.IsIdentity && it.PropertyInfo.PropertyType == typeof(short)))
+            {
+                setValue = Convert.ToInt16(idValue);
             }
             else
                 setValue = Convert.ToInt32(idValue);


### PR DESCRIPTION
当实体类的主键为ushort/short时
InsertReturnIdentity/InsertReturnEntity会引发类型异常
```csharp
System.ArgumentException: Object of type 'System.Int32' cannot be converted to type 'System.Int16'
````